### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:alpine
+WORKDIR /usr/src/app
+COPY handler.js .
+EXPOSE 8080
+
+COPY wait-for-settings.sh /usr/local/bin/
+ENTRYPOINT [ "wait-for-settings.sh" ]
+
+CMD ["node", "./handler.js"]

--- a/wait-for-settings.sh
+++ b/wait-for-settings.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+until [ -x /var/lib/chroma/iml-settings.conf ]; do
+  echo "Waiting for settings."
+  sleep 1
+done
+
+set -a
+source /var/lib/chroma/iml-settings.conf
+set +a
+
+exec $@


### PR DESCRIPTION
Update iml-update-check to be a separate docker service.

  - Add Dockerfile.
  - Add script that will wait until manager settings are available in
the container.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>