### PR TITLE
Update check timer does not fire on start

### DIFF
--- a/iml-update-check.timer
+++ b/iml-update-check.timer
@@ -4,6 +4,7 @@ PartOf=iml-storage-server.target
 After=network.target
 
 [Timer]
+OnActiveSec=10
 OnCalendar=daily
 AccuracySec=6h
 


### PR DESCRIPTION
Fixes #15.

iml-update-check.timer does not fire on startup.
It should have OnActiveSec=10 added to the timer.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>