### PR TITLE
Silence iml-update-check yum output

### DIFF
--- a/iml-update-check.py
+++ b/iml-update-check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2018 DDN. All rights reserved.
+# Copyright (c) 2019 DDN. All rights reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
@@ -19,32 +19,35 @@ from yum import YumBase
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 yp = YumBase()
+yp.preconf.debuglevel = 0
+yp.preconf.errorlevel = 0
 yp.getReposFromConfig()
 yp.doSackFilelistPopulate()
 
-packages = ['python2-iml-agent']
+packages = ["python2-iml-agent"]
 
-if 'IML_PROFILE_PACKAGES' in os.environ:
-    packages += os.environ['IML_PROFILE_PACKAGES'].split(',')
+if "IML_PROFILE_PACKAGES" in os.environ:
+    packages += os.environ["IML_PROFILE_PACKAGES"].split(",")
 
-ypl = yp.doPackageLists(pkgnarrow='updates', patterns=packages)
+ypl = yp.doPackageLists(pkgnarrow="updates", patterns=packages)
 
 has_updates = len(ypl.updates) > 0
 
-if 'IML_PROFILE_REPOS' in os.environ:
-    for bundle in os.environ['IML_PROFILE_REPOS'].split(','):
-        if bundle == 'external':
+if "IML_PROFILE_REPOS" in os.environ:
+    for bundle in os.environ["IML_PROFILE_REPOS"].split(","):
+        if bundle == "external":
             continue
-        ypl = yp.doPackageLists(pkgnarrow=['updates'], repoid=bundle)
+        ypl = yp.doPackageLists(pkgnarrow=["updates"], repoid=bundle)
         has_updates |= len(ypl.updates) > 0
 
 yp.close()
 
 resp = requests.post(
-    urljoin(os.environ['IML_MANAGER_URL'], 'iml_has_package_updates'),
-    cert=(os.environ['IML_CERT_PATH'], os.environ['IML_PRIVATE_KEY_PATH']),
+    urljoin(os.environ["IML_MANAGER_URL"], "iml_has_package_updates"),
+    cert=(os.environ["IML_CERT_PATH"], os.environ["IML_PRIVATE_KEY_PATH"]),
     verify=False,
-    headers={'Content-Type': 'application/json'},
-    data=json.dumps(has_updates))
+    headers={"Content-Type": "application/json"},
+    data=json.dumps(has_updates),
+)
 
-print "Manager responded, status code: {0}".format(resp.status_code)
+print("Manager responded, status code: {0}".format(resp.status_code))

--- a/iml-update-handler.socket
+++ b/iml-update-handler.socket
@@ -10,4 +10,4 @@ ListenStream=/var/run/iml-update-handler.sock
 RemoveOnStop=true
 
 [Install]
-WantedBy=sockets.target
+WantedBy=iml-manager.target


### PR DESCRIPTION
When `iml-update-check.py` runs, it spits all it's yum output into
stdout. This in turn makes the logs more verbose than necessary.

Disable the output.

  - Format file with black
  - Update `WantedBy` for `iml-update-handler.socket`.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>