### PR TITLE
Fix update check

### DIFF
--- a/iml-update-check.service
+++ b/iml-update-check.service
@@ -4,7 +4,6 @@ Description=IML Update Checker
 [Service]
 ExecStart=/usr/bin/iml-update-check
 EnvironmentFile=/etc/iml/manager-url.conf
-EnvironmentFile=/etc/iml/profile.conf
 Environment=IML_CERT_PATH=/etc/iml/self.crt IML_PRIVATE_KEY_PATH=/etc/iml/private.pem
 RestartSec=5min
 Restart=on-failure


### PR DESCRIPTION
The update check was depending on environment variables that no longer
can exist with server profile updates.

In addition, it appears we should be passing pkgnarrow a string instead
of a list.

The only reliable way I can find to detect updates is to read in the
/etc/yum.repos.d/Intel-Lustre-Agent.repo, which should include all the
repos specified by the manager.

Once we've read that in we can detect updates for only the repos in that
file.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>